### PR TITLE
Fix flipt compile error

### DIFF
--- a/crates/flipt/Cargo.toml
+++ b/crates/flipt/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flipt = "1.0.0"
+flipt = "= 1.1.1"
 open-feature = "0.2.2"
 serde_json = "1.0"
 # FIXME: openfeature-rust-sdk-contrib should export this


### PR DESCRIPTION
Closes https://github.com/open-feature/rust-sdk-contrib/issues/17

Also we fix the version of the flipt library to the latest (1.1.1).