### PR TITLE
chore: cargo package include only source code

### DIFF
--- a/crates/flagd/Cargo.toml
+++ b/crates/flagd/Cargo.toml
@@ -3,6 +3,15 @@ name = "open-feature-flagd"
 version = "0.0.2"
 edition = "2021"
 
+# This is needed to reduce package size
+include = [
+    "schemas/protobuf/flagd/evaluation/v1/evaluation.proto",
+    "schemas/protobuf/flagd/sync/v1/sync.proto",
+    "flagd-testbed/gherkin/config.feature",
+    "build.rs",
+    "src/*",
+]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Reduces package size of flagd to unblock cargo publish size limit problem

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

```
error: failed to publish to registry at https://crates.io/
Caused by:
  the remote server responded with an error (status 413 Payload Too Large): max upload size is: 10485760
```