### PR TITLE
fix: increase MSRV to correct version, delete unnecessary include

### DIFF
--- a/crates/flagd/Cargo.toml
+++ b/crates/flagd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open-feature-flagd"
 version = "0.0.3"
 edition = "2021"
-rust-version = "1.71.1" # MSRV
+rust-version = "1.80.1" # MSRV
 description = "The official flagd provider for OpenFeature."
 documentation = "https://docs.rs/open-feature-flagd"
 readme = "README.md"
@@ -14,7 +14,6 @@ license = "Apache-2.0"
 include = [
     "schemas/protobuf/flagd/evaluation/v1/evaluation.proto",
     "schemas/protobuf/flagd/sync/v1/sync.proto",
-    "flagd-testbed/gherkin/config.feature",
     "build.rs",
     "src/*",
 ]


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Fixes MSRV to correct version
- Removes test file from packaging include list

### Notes
<!-- any additional notes for this PR -->
```bash
$ cargo msrv find 
  [Meta]   cargo-msrv 0.18.1  

Compatibility Check #1: Rust 1.71.1
  [FAIL]   Is incompatible 
                                                                                    
  ╭────────────────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse lock file at: /Users/eatas/GitRepos/Github/rust-sdk-con │
  │ trib/Cargo.lock                                                                │
  │                                                                                │
  │ Caused by:                                                                     │
  │   lock file version `4` was found, but this version o                          │
  │ f Cargo does not understand this lock file, perhaps Cargo needs to be updated? │
  │                                                                                │
  ╰────────────────────────────────────────────────────────────────────────────────╯
                                                                                    

Compatibility Check #2: Rust 1.78.0
  [FAIL]   Is incompatible 
                                                                            
  ╭────────────────────────────────────────────────────────────────────────╮
  │     Updating crates.io index                                           │
  │  Downloading crates ...                                                │
  │   Downloaded datalogic-rs v2.1.2                                       │
  │   Downloaded native-tls v0.2.14                                        │
  │   Downloaded hickory-resolver v0.24.4                                  │
  │   Downloaded hickory-proto v0.24.4                                     │
  │ error: rustc 1.78.0 is not supported by the following packages:        │
  │   native-tls@0.2.14 requires rustc 1.80.0                              │
  │   native-tls@0.2.14 requires rustc 1.80.0                              │
  │   native-tls@0.2.14 requires rustc 1.80.0                              │
  │ Either upgrade rustc or select compatible dependency versions with     │
  │ `cargo update <name>@<current-ver> --precise <compatible-ver>`         │
  │ where `<compatible-ver>` is the latest version supporting rustc 1.78.0 │
  │                                                                        │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯
                                                                            

Compatibility Check #3: Rust 1.82.0
  [OK]     Is compatible 

Compatibility Check #4: Rust 1.80.1
  [OK]     Is compatible 

Compatibility Check #5: Rust 1.79.0
  [FAIL]   Is incompatible 
                                                                            
  ╭────────────────────────────────────────────────────────────────────────╮
  │ error: rustc 1.79.0 is not supported by the following packages:        │
  │   native-tls@0.2.14 requires rustc 1.80.0                              │
  │   native-tls@0.2.14 requires rustc 1.80.0                              │
  │   native-tls@0.2.14 requires rustc 1.80.0                              │
  │ Either upgrade rustc or select compatible dependency versions with     │
  │ `cargo update <name>@<current-ver> --precise <compatible-ver>`         │
  │ where `<compatible-ver>` is the latest version supporting rustc 1.79.0 │
  │                                                                        │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯
                                                                            

Result:
   Considered (min … max):   Rust 1.56.1 … Rust 1.85.0 
   Search method:            bisect                    
   MSRV:                     1.80.1                    
   Target:                   aarch64-apple-darwin 
```
