### PR TITLE
ci: run chcon only if selinux is enforcing, add more CI checks for flagd

### DIFF
--- a/.github/workflows/flagd-check.yml
+++ b/.github/workflows/flagd-check.yml
@@ -1,0 +1,43 @@
+name: Flagd Checks
+
+on:
+  push:
+    paths:
+      - 'crates/flagd/**'
+      - '.github/workflows/flagd-check.yml'
+  pull_request:
+    paths:
+      - 'crates/flagd/**'
+      - '.github/workflows/flagd-check.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update git submodules
+        run: git submodule update --init --recursive
+
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install cargo-msrv and cargo-readme
+        working-directory: crates/flagd
+        run: |
+          cargo install cargo-msrv --locked
+          cargo install cargo-readme
+
+      - name: Verify Minimum Supported Rust Version
+        working-directory: crates/flagd
+        run: cargo msrv verify
+
+      - name: Check README is up-to-date
+        working-directory: crates/flagd
+        run: |
+          cargo readme --no-title --no-license > README.md.generated
+          diff README.md README.md.generated
+


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Adds 2 new CI checks for flagd:
    - Checks whether cargo readme is correct to keep README.md up to date
    - Ensures MSRV is expected
- Updates test file creation to not run `chcon` if SELinux is not enforced

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

It was throwing unnecessary stderr logs if selinux is not enforced.