### PR TITLE
feat: Add `Send + Sync` trait bounds to error types in flagd `RpcResolver`

### DIFF
--- a/crates/flagd/src/resolver/rpc.rs
+++ b/crates/flagd/src/resolver/rpc.rs
@@ -92,7 +92,7 @@ pub struct RpcResolver {
 
 impl RpcResolver {
     #[instrument(skip(options))]
-    pub async fn new(options: &FlagdOptions) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(options: &FlagdOptions) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         debug!("initializing RPC resolver connection to {}", options.host);
 
         let mut retry_delay = Duration::from_millis(options.retry_backoff_ms as u64);
@@ -131,7 +131,7 @@ impl RpcResolver {
 
     async fn establish_connection(
         options: &FlagdOptions,
-    ) -> Result<ClientType, Box<dyn std::error::Error>> {
+    ) -> Result<ClientType, Box<dyn std::error::Error + Send + Sync>> {
         if let Some(socket_path) = &options.socket_path {
             debug!("Attempting Unix socket connection to: {}", socket_path);
             let socket_path = socket_path.clone();

--- a/crates/flagd/src/resolver/rpc.rs
+++ b/crates/flagd/src/resolver/rpc.rs
@@ -92,7 +92,9 @@ pub struct RpcResolver {
 
 impl RpcResolver {
     #[instrument(skip(options))]
-    pub async fn new(options: &FlagdOptions) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn new(
+        options: &FlagdOptions,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         debug!("initializing RPC resolver connection to {}", options.host);
 
         let mut retry_delay = Duration::from_millis(options.retry_backoff_ms as u64);


### PR DESCRIPTION
## This PR
This pull request adds the `Send` and `Sync` trait bounds to the errors returned by flagd's `RpcResolver::new` and `RpcResolver::establish_connection`. This effectively only changes the return types from `Result<_, Box<dyn std::error::Error>>` to `Result<_, Box<dyn std::error::Error + Send + Sync>>`.

### Notes
I noticed the lack of the `Send` and `Sync` trait bounds of the returned values when using the flagd provider in an async context. The compilation error I got was as follows:
```
`dyn std::error::Error` cannot be sent between threads safely
the trait `std::marker::Send` is not implemented for `dyn std::error::Error`
```
After extracting the problematic lines in the code, I asked for help on the Rust forum on what exactly the problem is here. They kindly helped me out to understand what's going on. For anyone interested, here's a link to my [forum post](https://users.rust-lang.org/t/async-function-returning-send-compile-error-using-match-and-tokio-sleep-but-if-let-works/129611).
