### PR TITLE
flagd: Update dependencies, reuse reqwest client for better performance, add cargo audit to CI

### DIFF
--- a/crates/flagd/Cargo.toml
+++ b/crates/flagd/Cargo.toml
@@ -21,9 +21,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tonic-build = "0.12"
-prost = "0.13"
-prost-build = "0.13"
+tonic-build = "0.13"
 
 [dev-dependencies]
 cucumber = "0.21"
@@ -31,30 +29,27 @@ tokio-stream = "0.1"
 futures-core = "0.3"
 testcontainers = { version = "0.24.0", features = ["http_wait", "blocking"] }
 wiremock = "0.6.3"
-tempfile = "3.19.0"
+tempfile = "3.20.0"
 serial_test = "3.2"
-tracing-test = "0.2"
 test-log = { version = "0.2", features = ["trace"] }
 
 [dependencies]
 open-feature = "0.2"
 async-trait = "0.1"
-tonic = { version = "0.12", features = ["tls"] }
+tonic = { version = "0.13" }
 prost = "0.13"
 prost-types = "0.13"
-tokio = { version = "1.44", features = ["full"] }
+tokio = { version = "1.45", features = ["full"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 lru = "0.14"
 futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
-anyhow = "1.0.97"
-regex = "1.11.1"
+anyhow = "1.0.98"
 semver = "1.0.26"
 murmurhash3 = "0.0.5"
 tower = "0.5"
 hyper-util = { version = "0.1", features = ["tokio"] }
 thiserror = "2.0"
-datalogic-rs = "3.0.22"
+datalogic-rs = "3.0.24"

--- a/crates/flagd/src/resolver/rest.rs
+++ b/crates/flagd/src/resolver/rest.rs
@@ -50,6 +50,7 @@ use open_feature::{
 };
 use serde_json;
 use tracing::{debug, error, instrument};
+use reqwest::Client;
 
 use crate::FlagdOptions;
 
@@ -60,6 +61,8 @@ pub struct RestResolver {
     endpoint: String,
     /// Provider metadata
     metadata: ProviderMetadata,
+    /// HTTP client for making requests
+    client: Client,
 }
 
 impl RestResolver {
@@ -81,6 +84,7 @@ impl RestResolver {
         Self {
             endpoint,
             metadata: ProviderMetadata::new("flagd-rest-provider"),
+            client: Client::new(),
         }
     }
 }
@@ -108,12 +112,12 @@ impl FeatureProvider for RestResolver {
         evaluation_context: &EvaluationContext,
     ) -> EvaluationResult<ResolutionDetails<bool>> {
         debug!("Resolving boolean flag");
-        let client = reqwest::Client::new();
+    
         let payload = serde_json::json!({
             "context": context_to_json(evaluation_context)
         });
 
-        let response = client
+        let response = self.client
             .post(format!(
                 "{}/ofrep/v1/evaluate/flags/{}",
                 self.endpoint, flag_key
@@ -176,12 +180,12 @@ impl FeatureProvider for RestResolver {
         evaluation_context: &EvaluationContext,
     ) -> EvaluationResult<ResolutionDetails<String>> {
         debug!("Resolving string flag");
-        let client = reqwest::Client::new();
+    
         let payload = serde_json::json!({
             "context": context_to_json(evaluation_context)
         });
 
-        let response = client
+        let response = self.client
             .post(format!(
                 "{}/ofrep/v1/evaluate/flags/{}",
                 self.endpoint, flag_key
@@ -247,12 +251,12 @@ impl FeatureProvider for RestResolver {
         evaluation_context: &EvaluationContext,
     ) -> EvaluationResult<ResolutionDetails<f64>> {
         debug!("Resolving float flag");
-        let client = reqwest::Client::new();
+    
         let payload = serde_json::json!({
             "context": context_to_json(evaluation_context)
         });
 
-        let response = client
+        let response = self.client
             .post(format!(
                 "{}/ofrep/v1/evaluate/flags/{}",
                 self.endpoint, flag_key
@@ -313,12 +317,12 @@ impl FeatureProvider for RestResolver {
         evaluation_context: &EvaluationContext,
     ) -> EvaluationResult<ResolutionDetails<i64>> {
         debug!("Resolving integer flag");
-        let client = reqwest::Client::new();
+    
         let payload = serde_json::json!({
             "context": context_to_json(evaluation_context)
         });
 
-        let response = client
+        let response = self.client
             .post(format!(
                 "{}/ofrep/v1/evaluate/flags/{}",
                 self.endpoint, flag_key
@@ -382,12 +386,12 @@ impl FeatureProvider for RestResolver {
         evaluation_context: &EvaluationContext,
     ) -> EvaluationResult<ResolutionDetails<StructValue>> {
         debug!("Resolving struct flag");
-        let client = reqwest::Client::new();
+    
         let payload = serde_json::json!({
             "context": context_to_json(evaluation_context)
         });
 
-        let response = client
+        let response = self.client
             .post(format!(
                 "{}/ofrep/v1/evaluate/flags/{}",
                 self.endpoint, flag_key


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Updates all dependencies for flagd
- Adds a simple change where same reqwest http client is used to reduce overhead by client initialization for OFREP.
- Adds `cargo audit` for vulnerability checks

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #44 
