### PR TITLE
fix: extend flagd ci to ofrep, add msrv

### DIFF
--- a/.github/workflows/flagd-ofrep-check.yml
+++ b/.github/workflows/flagd-ofrep-check.yml
@@ -4,11 +4,13 @@ on:
   push:
     paths:
       - 'crates/flagd/**'
-      - '.github/workflows/flagd-check.yml'
+      - 'crates/ofrep/**'
+      - '.github/workflows/flagd-ofrep-check.yml'
   pull_request:
     paths:
       - 'crates/flagd/**'
-      - '.github/workflows/flagd-check.yml'
+      - 'crates/ofrep/**'
+      - '.github/workflows/flagd-ofrep-check.yml'
 
 jobs:
   check:

--- a/crates/ofrep/Cargo.toml
+++ b/crates/ofrep/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/open-feature/rust-sdk-contrib"
 version = "0.0.3"
 edition = "2024"
+rust-version = "1.85.1"
 
 [dev-dependencies]
 wiremock = "0.6.3"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Extends flagd ci to OFREP crate to ensure it does same checks
- Adds MSRV 1.85.1 after checking with cargo-msrv
- Hopefully will fix publish issue

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/open-feature/rust-sdk-contrib/actions/runs/16576658163/job/46882500086
