### PR TITLE
feat: add renaming mechanism for EnvVarProvider

### DIFF
--- a/crates/env-var/README.md
+++ b/crates/env-var/README.md
@@ -43,6 +43,17 @@ if is_feature_enabled {
 }
 ```
 
+The environment variable names can be customized by injecting a custom `Rename` implementation:
+
+```rust
+/// Transforms env-flag-key to ENV_FLAG_KEY
+fn underscore(flag_key: &str) -> Cow<'_, str> {
+    flag_key.replace("-", "_").to_uppercase().into()
+}
+
+let provider  = EnvVarProvider::new(underscore);
+```
+
 ## Testing
 
 Run `cargo test` to execute tests.


### PR DESCRIPTION
EnvVarProvider now supports injecting a custom renaming strategy, which allows users to customise how environment variables are selected by transforming the requested flag key.

## This PR

- adds the `Rename` trait to `EnvVarProvider`, which allows users to inject custom strategies for transforming flag keys into the corresponding environment variable name.

### How to test

Unit tests have been added. I tried to add a case to the Cucumber world, but I'm not familiar with that system, and I had issues injecting a generic `R` into the World.

