### PR TITLE
ci: upgrade release-please to v4 and add cargo-workspace plugin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,13 +16,10 @@ jobs:
       pull-requests: write # for googleapis/release-please-action to create release PR
     # Release-please creates a PR that tracks all changes
     steps:
-      - uses: googleapis/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
-          command: manifest
           token: ${{secrets.RELEASE_PLEASE_ACTION_TOKEN}}
-          default-branch: main
-          signoff: "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>"
       - name: Dump Release Please Output
         env:
           RELEASE_PLEASE_OUTPUT: ${{ toJson(steps.release.outputs) }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,14 +6,17 @@
   "packages": {
     "crates/env-var": {},
     "crates/flagd": {
-      "package-group": "flagd-group"
+      "package-group": "flagd-group",
+      "separate-pull-requests": false
     },
     "crates/flagd-evaluation-engine": {
-      "package-group": "flagd-group"
+      "package-group": "flagd-group",
+      "separate-pull-requests": false
     },
     "crates/flipt": {},
     "crates/ofrep": {
-      "package-group": "flagd-group"
+      "package-group": "flagd-group",
+      "separate-pull-requests": false
     }
   },
   "changelog-sections": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,23 +1,21 @@
 {
   "separate-pull-requests": true,
   "release-type": "rust",
+  "signoff": "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    }
+  ],
   "packages": {
     "crates/env-var": {},
-    "crates/flagd": {
-      "package-group": "flagd-group",
-      "separate-pull-requests": false
-    },
-    "crates/flagd-evaluation-engine": {
-      "package-group": "flagd-group",
-      "separate-pull-requests": false
-    },
+    "crates/flagd": {},
+    "crates/flagd-evaluation-engine": {},
     "crates/flipt": {},
-    "crates/ofrep": {
-      "package-group": "flagd-group",
-      "separate-pull-requests": false
-    }
+    "crates/ofrep": {}
   },
   "changelog-sections": [
     {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,11 @@
     {
       "type": "cargo-workspace",
       "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "flagd",
+      "components": ["open-feature-flagd", "flagd-evaluation-engine", "open-feature-ofrep"]
     }
   ],
   "packages": {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Should solve CI issues such as https://github.com/open-feature/rust-sdk-contrib/pull/112 where only evaluation engine version is updated but then it can't find that version locally or in crates.io. This change should keep those changes in same PR
