### PR TITLE
ci: scope release-please PR checks to changed crate only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,8 +35,28 @@ jobs:
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Run all workspace tests
-      run:  cargo test --workspace --verbose
+    - name: Run workspace tests
+      if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+      run: cargo test --workspace --verbose
+
+    - name: Run release crate tests
+      if: ${{ startsWith(github.head_ref, 'release-please--') }}
+      run: |
+        COMPONENT=$(echo "${{ github.head_ref }}" | sed 's/release-please--branches--main--components--//')
+        CRATE_DIR=$(find crates -maxdepth 1 -type d | while read dir; do
+          if [ -f "$dir/Cargo.toml" ]; then
+            PKG=$(grep '^name = ' "$dir/Cargo.toml" | head -1 | sed 's/name = "//;s/"//')
+            if [ "$PKG" = "$COMPONENT" ]; then
+              echo "$dir"
+              break
+            fi
+          fi
+        done)
+        if [ -n "$CRATE_DIR" ]; then
+          cargo test -p "$COMPONENT" --verbose
+        else
+          cargo test --workspace --verbose
+        fi
 
   lint:
     runs-on: ubuntu-latest
@@ -51,4 +71,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Check code quality
+        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
         run: cargo clippy -- -D warnings
+
+      - name: Check release crate quality
+        if: ${{ startsWith(github.head_ref, 'release-please--') }}
+        run: |
+          COMPONENT=$(echo "${{ github.head_ref }}" | sed 's/release-please--branches--main--components--//')
+          cargo clippy -p "$COMPONENT" -- -D warnings

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,11 +8,6 @@
     {
       "type": "cargo-workspace",
       "merge": false
-    },
-    {
-      "type": "linked-versions",
-      "groupName": "flagd",
-      "components": ["open-feature-flagd", "flagd-evaluation-engine", "open-feature-ofrep"]
     }
   ],
   "packages": {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This change runs `cargo test -p <component>` and `cargo clippy -p <component>` instead of `--workspace` to avoid version resolution failures caused by consumers referencing the pre-release version of a dependency that hasn't been published yet. 

It also removes the unused linked-versions plugin from release-please-config.json; cargo-workspace alone handles cross-crate dependency version updates.