### PR TITLE
ci: fix publish for flagd family

### DIFF
--- a/crates/flagd-evaluation-engine/README.md
+++ b/crates/flagd-evaluation-engine/README.md
@@ -10,7 +10,6 @@ A JSONLogic-based evaluation engine for flagd, providing local flag evaluation w
 - **String Operations**: Custom operators for "starts_with" and "ends_with" comparisons
 
 ## Installation
-
 Add the dependency in your `Cargo.toml`:
 
 ```bash

--- a/crates/ofrep/README.md
+++ b/crates/ofrep/README.md
@@ -13,7 +13,6 @@ cargo add open-feature-ofrep
 cargo add open-feature
 ```
 Then integrate it into your application:
-
 ```rust
 use std::time::Duration;
 use open_feature::provider::FeatureProvider;

--- a/crates/ofrep/src/lib.rs
+++ b/crates/ofrep/src/lib.rs
@@ -13,7 +13,6 @@
 //! cargo add open-feature
 //! ```
 //! Then integrate it into your application:
-//!
 //! ```rust,no_run
 //! use std::time::Duration;
 //! use open_feature::provider::FeatureProvider;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "signoff": "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "group-pull-request-title-pattern": "chore: release flagd family",
+  "group-pull-request-title-pattern": "chore${scope}: release flagd family",
   "plugins": [
     {
       "type": "cargo-workspace",


### PR DESCRIPTION
This will render as chore(main): release flagd family, which release-please can parse.