### PR TITLE
chore(deps): update open-feature to 0.3.0 in env-var provider

### DIFF
--- a/crates/env-var/Cargo.toml
+++ b/crates/env-var/Cargo.toml
@@ -14,15 +14,15 @@ keywords = ["open-feature", "feature-flag", "environment-variable"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-open-feature = "0.2.7"
+open-feature = "0.3.0"
 async-trait = "0.1.89"
 
 [dev-dependencies]
 tokio = { version = "1.48.0", features = ["full"] }
-cucumber = "0.22.0"
+cucumber = "0.23.0"
 futures = "0.3.31"
-test-with = { version = "0.15", features = ["runtime"] }
-libtest-with = { version = "0.8.1-12" }
+test-with = { version = "0.16.3", features = ["runtime"] }
+libtest-with = { version = "0.8.1-14" }
 temp-env = "0.3"
 
 [[test]]


### PR DESCRIPTION
## This PR

Updates the `env-var` provider to the latest OpenFeature SDK and test dependencies.

- Bumps `open-feature` from `0.2.7` to `0.3.0`
- Bumps dev-dependencies:
  - `cucumber` `0.22.0` → `0.23.0`
  - `test-with` `0.15` → `0.16.3`
  - `libtest-with` `0.8.1-12` → `0.8.1-14`

### Notes

No source changes were required — the `0.2.7` → `0.3.0` bump is API-compatible for this provider.

### How to test

```bash
cargo test -p open-feature-env-var
```

All tests pass:
- Cucumber: 5 scenarios / 15 steps passed
- Unit tests passed
- Doc-tests: 8 passed