### PR TITLE
feat(flagd): make the tonic rustls backend selectable (tls-ring default, tls-aws-lc opt-in)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1.52", features = ["sync", "time", "fs", "rt", "rt-multi-th
 notify = "8.2"
 
 # gRPC
-tonic = { version = "0.14", default-features = false, features = ["transport", "codegen", "tls-ring", "tls-webpki-roots"] }
+tonic = { version = "0.14", default-features = false, features = ["transport", "codegen", "tls-webpki-roots"] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 prost = "0.14"

--- a/crates/flagd/Cargo.toml
+++ b/crates/flagd/Cargo.toml
@@ -23,7 +23,14 @@ include = [
 ]
 
 [features]
-default = ["rpc", "rest", "in-process"]
+default = ["rpc", "rest", "in-process", "tls-ring"]
+# rustls crypto backend for the gRPC transport — exactly one should be enabled.
+# `tls-ring` matches the previous hard-coded behaviour; `tls-aws-lc` is for applications
+# whose dependency graph already standardises on aws-lc-rs (e.g. anything using the AWS SDK),
+# where enabling ring as well makes rustls unable to auto-select a CryptoProvider and
+# panic at first TLS use.
+tls-ring = ["tonic?/tls-ring"]
+tls-aws-lc = ["tonic?/tls-aws-lc"]
 # RPC evaluation mode - uses gRPC to connect to flagd service
 rpc = ["dep:tonic", "dep:tonic-prost", "dep:prost", "dep:prost-types", "dep:hyper-util", "dep:tower"]
 # REST evaluation mode - uses HTTP/OFREP to connect to flagd service


### PR DESCRIPTION
## This PR
open-feature-flagd unconditionally enables tonic's tls-ring, which enables rustls/ring. Applications whose graphs already use rustls/aws-lc-rs (anything with the AWS SDK, and rustls' own default) then have both provider features enabled, and rustls 0.23 panics at first TLS use: "Could not automatically determine the process-level CryptoProvider from Cargo feature flags." Because cargo features are additive, consumers cannot opt out. This PR keeps tls-ring as the default (non-breaking) and adds a tls-aws-lc alternative, both forwarded to tonic as weak features.

### How to test
Standard tests should just work as is as this doesn't change any of the engine itself and just the crypto provider

