### PR TITLE
chore: Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>open-feature/community-tooling",
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "dependencyDashboardApproval": false,
   "packageRules": [
     {
       "groupName": "patching",

--- a/renovate.json
+++ b/renovate.json
@@ -15,14 +15,6 @@
       "dependencyDashboardCategory": "{{updateType}} {{categories}} updates",
       "dependencyDashboardFooter": "These updates will also require pr approvals unless they are minor devDependencies.",
       "matchUpdateTypes": ["major", "minor"],
-      "matchCategories": ["!ci", "!docker"]
-    },
-    {
-      "dependencyDashboardCategory": "{{updateType}} infra updates",
-      "dependencyDashboardFooter": "These updates will often auto-merge on ci passing but may require pr approvals.",
-      "dependencyDashboardHeader": "Contains updates to both ci (github actions) & docker dependencies",
-      "matchUpdateTypes": ["major", "minor"],
-      "matchCategories": ["ci", "docker"]
     },
     {
       "matchUpdateTypes": ["minor"],

--- a/renovate.json
+++ b/renovate.json
@@ -5,26 +5,32 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  "dependencyDashboardApproval": false,
   "packageRules": [
     {
-      "groupName": "patching",
-      "matchUpdateTypes": ["patch", "digest"],
-      "schedule": ["before 6am on Weekday"]
+      "dependencyDashboardCategory": "Dependency patches",
+      "dependencyDashboardFooter": "These updates will auto-merge on ci passing.",
+      "matchUpdateTypes": ["patch", "digest"]
     },
     {
-      "groupName": "minor infra",
+      "dependencyDashboardCategory": "{{updateType}} infra updates",
+      "dependencyDashboardFooter": "These updates will often auto-merge on ci passing but may require pr approvals.",
+      "dependencyDashboardHeader": "Contains updates to both ci (github actions) & docker dependencies",
+      "matchUpdateTypes": ["major", "minor"],
+      "matchCategories": ["ci", "docker"]
+    },
+    {
       "matchUpdateTypes": ["minor"],
-      "matchCategories": ["ci", "docker"],
+      "matchCategories": ["rust"],
+      "matchDepTypes": [
+        "!devDependencies"
+      ],
+      "dependencyDashboardApproval": false,
       "schedule": ["before 7am on Monday"]
     },
     {
-      "matchUpdateTypes": ["minor"],
-      "schedule": ["before 7am on Monday"]
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "schedule": ["before 8am on Monday"]
+      "dependencyDashboardCategory": "{{updateType}} {{categories}} updates",
+      "dependencyDashboardFooter": "These updates will also require pr approvals unless they are minor devDependencies."
+      "matchUpdateTypes": ["major", "minor"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,12 @@
       "matchUpdateTypes": ["patch", "digest"]
     },
     {
+      "dependencyDashboardCategory": "{{updateType}} {{categories}} updates",
+      "dependencyDashboardFooter": "These updates will also require pr approvals unless they are minor devDependencies.",
+      "matchUpdateTypes": ["major", "minor"],
+      "matchCategories": ["!ci", "!docker"]
+    },
+    {
       "dependencyDashboardCategory": "{{updateType}} infra updates",
       "dependencyDashboardFooter": "These updates will often auto-merge on ci passing but may require pr approvals.",
       "dependencyDashboardHeader": "Contains updates to both ci (github actions) & docker dependencies",
@@ -26,11 +32,6 @@
       ],
       "dependencyDashboardApproval": false,
       "schedule": ["before 7am on Monday"]
-    },
-    {
-      "dependencyDashboardCategory": "{{updateType}} {{categories}} updates",
-      "dependencyDashboardFooter": "These updates will also require pr approvals unless they are minor devDependencies."
-      "matchUpdateTypes": ["major", "minor"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
     },
     {
       "dependencyDashboardCategory": "{{parentDir}} updates",
-      "dependencyDashboardFooter": "These updates will require manual pr approval/merge if they are a major update. Otherwise they will auto-merge on ci passing.",
+      "dependencyDashboardFooter": "These updates will require manual pr approval/merge if they are a major/minor update. Otherwise they will auto-merge on ci passing.",
       "matchCategories": ["rust"],
       "additionalBranchPrefix": "{{parentDir}}-"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,28 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "packageRules": [
+    {
+      "groupName": "patching",
+      "matchUpdateTypes": ["patch", "digest"],
+      "schedule": ["before 6am on Weekday"]
+    },
+    {
+      "groupName": "minor infra",
+      "matchUpdateTypes": ["minor"],
+      "matchCategories": ["ci", "docker"],
+      "schedule": ["before 7am on Monday"]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "schedule": ["before 7am on Monday"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "schedule": ["before 8am on Monday"]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,15 +13,18 @@
     },
     {
       "dependencyDashboardCategory": "{{updateType}} {{categories}} updates",
-      "dependencyDashboardFooter": "These updates will also require pr approvals unless they are minor devDependencies.",
-      "matchUpdateTypes": ["major", "minor"],
+      "dependencyDashboardFooter": "These updates will require a manual pr approval/merge if they are a major update. Otherwise they will auto-merge on ci passing.",
+      "matchUpdateTypes": ["major", "minor"]
+    },
+    {
+      "dependencyDashboardCategory": "{{parentDir}} updates",
+      "dependencyDashboardFooter": "These updates will require manual pr approval/merge if they are a major update. Otherwise they will auto-merge on ci passing.",
+      "matchCategories": ["rust"],
+      "additionalBranchPrefix": "{{parentDir}}-"
     },
     {
       "matchUpdateTypes": ["minor"],
       "matchCategories": ["rust"],
-      "matchDepTypes": [
-        "!devDependencies"
-      ],
       "dependencyDashboardApproval": false,
       "schedule": ["before 7am on Monday"]
     }


### PR DESCRIPTION
## This PR

- introduces control of when renovate pr’s are raised in the case of minor updates
- groups update’s together on the dashboard to reduce approvals needed & provide additional context.
