### PR TITLE
chore(deps): bump flagsmith sdk to 3.0

### DIFF
--- a/crates/flagsmith/Cargo.toml
+++ b/crates/flagsmith/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["openfeature", "feature-flags", "flagsmith"]
 open-feature = "0.2"
 
 # Flagsmith SDK
-flagsmith = "2.1"
+flagsmith = "3.0"
 
 # Async runtime
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
@@ -34,9 +34,7 @@ tracing = "0.1"
 
 # URL validation
 url = "2.5"
-
-# HTTP client (for HeaderMap type) - must match flagsmith's reqwest version
-reqwest = { version = "0.11", default-features = false }
+http = "1"
 
 # Flagsmith flag engine types (must match flagsmith version)
 flagsmith-flag-engine = "0.6"

--- a/crates/flagsmith/src/lib.rs
+++ b/crates/flagsmith/src/lib.rs
@@ -53,6 +53,7 @@ pub mod error;
 use async_trait::async_trait;
 use flagsmith::{Flagsmith, FlagsmithOptions as FlagsmithSDKOptions};
 use flagsmith_flag_engine::types::{FlagsmithValue, FlagsmithValueType};
+use http::HeaderMap;
 use open_feature::provider::{FeatureProvider, ProviderMetadata, ResolutionDetails};
 use open_feature::{
     EvaluationContext, EvaluationContextFieldValue, EvaluationError, EvaluationReason as Reason,
@@ -104,7 +105,7 @@ pub struct FlagsmithOptions {
     pub api_url: Option<String>,
 
     /// Custom HTTP headers
-    pub custom_headers: Option<reqwest::header::HeaderMap>,
+    pub custom_headers: Option<HeaderMap>,
 
     /// Request timeout in seconds
     pub request_timeout_seconds: Option<u64>,

--- a/crates/flagsmith/tests/integration_tests.rs
+++ b/crates/flagsmith/tests/integration_tests.rs
@@ -3,7 +3,6 @@ use flagsmith_flag_engine::types::{FlagsmithValue, FlagsmithValueType};
 use open_feature::provider::FeatureProvider;
 use open_feature::{EvaluationContext, EvaluationReason as Reason};
 use open_feature_flagsmith::{FlagsmithClient, FlagsmithProvider};
-use serde_json;
 use std::collections::HashMap;
 use std::sync::Arc;
 


### PR DESCRIPTION
## This PR
Bump the flagsmith sdk to its latest version 3.0.0.
This most notably allows depends on the latest version of reqwest, the main motivation can be found here: https://github.com/Flagsmith/flagsmith-rust-client/pull/49

### Notes
There is no need to actually pull the `reqwest` crate ourselve for the headermap as it is a re-export of the `http` crate which is stable.
